### PR TITLE
rocketchat: fix reactToMessages callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,8 @@ function RocketChat(skyfall) {
           source: id
         });
 
-        return driver.reactToMessages((error, message) => {
+        return driver.reactToMessages((error, messages) => {
+          message = messages[0]
           if (error) {
             skyfall.events.emit({
               type: `rocketchat:${ name }:error`,


### PR DESCRIPTION
rocketchat is dumb and sends an array of one message since version 3.8.0.
see https://github.com/RocketChat/Rocket.Chat/pull/20801
this is scheduled to be fixed in version 3.12.0